### PR TITLE
PCP-7054: Bump Go builder to 1.26.4 to fix CVEs

### DIFF
--- a/.github/workflows/spectro-release.yaml
+++ b/.github/workflows/spectro-release.yaml
@@ -62,8 +62,8 @@ jobs:
         name: Build Image
         env:
           REGISTRY: ${{ env.LEGACY_REGISTRY }}
-          GO_VERSION: 1.26.3
-          BUILDER_GOLANG_VERSION: 1.26.3
+          GO_VERSION: 1.26.4
+          BUILDER_GOLANG_VERSION: 1.26.4
         run: |
           make docker-build-all
           make docker-push-all
@@ -72,8 +72,8 @@ jobs:
         env:
           FIPS_ENABLE: yes
           REGISTRY: ${{ env.FIPS_REGISTRY }}
-          GO_VERSION: 1.26.3
-          BUILDER_GOLANG_VERSION: 1.26.3
+          GO_VERSION: 1.26.4
+          BUILDER_GOLANG_VERSION: 1.26.4
         run: |
           make docker-build-all
           make docker-push-all


### PR DESCRIPTION
Upgrade GO_VERSION and BUILDER_GOLANG_VERSION from 1.26.3 to 1.26.4 to address CVE-2026-42504, CVE-2026-27145, and CVE-2026-42507.